### PR TITLE
Do not require units for line-height by default

### DIFF
--- a/src/stylelint-require-units.js
+++ b/src/stylelint-require-units.js
@@ -44,7 +44,6 @@ let checkedProperties = [
   "height",
   "left",
   "letter-spacing",
-  "line-height",
   "margin",
   "margin-bottom",
   "margin-left",


### PR DESCRIPTION
Resolves https://github.com/matterialize/stylelint-require-units/issues/18